### PR TITLE
Splicing Throwables

### DIFF
--- a/scalalogging-slf4j-test/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
+++ b/scalalogging-slf4j-test/src/test/scala/com/typesafe/scalalogging/LoggerSpec.scala
@@ -23,6 +23,7 @@ import org.specs2.mutable.Specification
 object LoggerSpec extends Specification with Mockito {
 
   private val Message = "Some log message!"
+  private val Exception = new Exception("Some exception")
 
   "Calling a not-enabled logging method" should {
     "result in the underlying method not being called" in {
@@ -37,6 +38,8 @@ object LoggerSpec extends Specification with Mockito {
       there was no(underlying).trace(Message, "p1", "p2")
       logger.trace(Message, Array("p1", "p2", "p3"))
       there was no(underlying).trace(Message, Array("p1", "p2", "p3"))
+      logger.trace(Message, Exception)
+      there was no(underlying).trace(Message, Exception)
     }
   }
 
@@ -53,6 +56,8 @@ object LoggerSpec extends Specification with Mockito {
       there was one(underlying).error(Message, "p1", "p2")
       logger.error(Message, Array("p1", "p2", "p3"))
       there was one(underlying).error(Message, Array("p1", "p2", "p3"))
+      logger.error(Message, Exception)
+      there was one(underlying).error(Message, Exception)
     }
   }
 
@@ -69,6 +74,8 @@ object LoggerSpec extends Specification with Mockito {
       there was one(underlying).warn(Message, "p1", "p2")
       logger.warn(Message, Array("p1", "p2", "p3"))
       there was one(underlying).warn(Message, Array("p1", "p2", "p3"))
+      logger.warn(Message, Exception)
+      there was one(underlying).warn(Message, Exception)
     }
   }
 
@@ -85,6 +92,8 @@ object LoggerSpec extends Specification with Mockito {
       there was one(underlying).info(Message, "p1", "p2")
       logger.info(Message, Array("p1", "p2", "p3"))
       there was one(underlying).info(Message, Array("p1", "p2", "p3"))
+      logger.info(Message, Exception)
+      there was one(underlying).info(Message, Exception)
     }
   }
 
@@ -101,6 +110,8 @@ object LoggerSpec extends Specification with Mockito {
       there was one(underlying).debug(Message, "p1", "p2")
       logger.debug(Message, Array("p1", "p2", "p3"))
       there was one(underlying).debug(Message, Array("p1", "p2", "p3"))
+      logger.debug(Message, Exception)
+      there was one(underlying).debug(Message, Exception)
     }
   }
 
@@ -117,6 +128,8 @@ object LoggerSpec extends Specification with Mockito {
       there was one(underlying).trace(Message, "p1", "p2")
       logger.trace(Message, Array("p1", "p2", "p3"))
       there was one(underlying).trace(Message, Array("p1", "p2", "p3"))
+      logger.trace(Message, Exception)
+      there was one(underlying).trace(Message, Exception)
     }
   }
 }

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/Logger.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/Logger.scala
@@ -113,7 +113,7 @@ private object LoggerMacros {
   )
 
   def errorT(c: LoggerContext)(message: c.Expr[String], t: c.Expr[Throwable]) = c.universe.reify(
-    if (c.prefix.splice.underlying.isErrorEnabled) c.prefix.splice.underlying.error(message.splice, t)
+    if (c.prefix.splice.underlying.isErrorEnabled) c.prefix.splice.underlying.error(message.splice, t.splice)
   )
 
   def warn(c: LoggerContext)(message: c.Expr[String]) = c.universe.reify(
@@ -136,7 +136,7 @@ private object LoggerMacros {
   )
 
   def warnT(c: LoggerContext)(message: c.Expr[String], t: c.Expr[Throwable]) = c.universe.reify(
-    if (c.prefix.splice.underlying.isWarnEnabled) c.prefix.splice.underlying.warn(message.splice, t)
+    if (c.prefix.splice.underlying.isWarnEnabled) c.prefix.splice.underlying.warn(message.splice, t.splice)
   )
 
   def info(c: LoggerContext)(message: c.Expr[String]) = c.universe.reify(
@@ -159,7 +159,7 @@ private object LoggerMacros {
   )
 
   def infoT(c: LoggerContext)(message: c.Expr[String], t: c.Expr[Throwable]) = c.universe.reify(
-    if (c.prefix.splice.underlying.isInfoEnabled) c.prefix.splice.underlying.info(message.splice, t)
+    if (c.prefix.splice.underlying.isInfoEnabled) c.prefix.splice.underlying.info(message.splice, t.splice)
   )
 
   def debug(c: LoggerContext)(message: c.Expr[String]) = c.universe.reify(
@@ -182,7 +182,7 @@ private object LoggerMacros {
   )
 
   def debugT(c: LoggerContext)(message: c.Expr[String], t: c.Expr[Throwable]) = c.universe.reify(
-    if (c.prefix.splice.underlying.isDebugEnabled) c.prefix.splice.underlying.debug(message.splice, t)
+    if (c.prefix.splice.underlying.isDebugEnabled) c.prefix.splice.underlying.debug(message.splice, t.splice)
   )
 
   def trace(c: LoggerContext)(message: c.Expr[String]) = c.universe.reify(
@@ -205,6 +205,6 @@ private object LoggerMacros {
   )
 
   def traceT(c: LoggerContext)(message: c.Expr[String], t: c.Expr[Throwable]) = c.universe.reify(
-    if (c.prefix.splice.underlying.isTraceEnabled) c.prefix.splice.underlying.trace(message.splice, t)
+    if (c.prefix.splice.underlying.isTraceEnabled) c.prefix.splice.underlying.trace(message.splice, t.splice)
   )
 }


### PR DESCRIPTION
Hi Heiko

I just observed that the following snippet leads to a compile error:

``` scala
package com.typesafe.scalalogging

object MacroCompileTest extends Logging {
  val reporter = (t: Throwable) => logger.error("msg", t)
}
```

```
[error] /home/dk/fhnw/projects/finnova/git/scalalogging/scalalogging-slf4j-test/src/test/scala/com/typesafe/scalalogging/MacroCompileTest.scala:4: Macro expansion contains free term variable t defined by errorT in Logger.scala:115:57. Have you forgotten to use splice when splicing this variable into a reifee? If you have troubles tracking free term variables, consider using -Xlog-free-terms
[error]   val reporter = (t: Throwable) => logger.error("msg", t)
[error]                                                ^
[error] one error found
[error] (scalalogging-slf4j-test/test:compile) Compilation failed
[error] Total time: 6 s, completed Aug 21, 2012 9:44:41 AM
```

I just added the required 'splice' calls and some tests.

Thanks for making your library official!
Daniel
