### PR TITLE
Move abstract logging

### DIFF
--- a/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogger.scala
+++ b/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogger.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2012 Typesafe Inc. <http://www.typesafe.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.scalalogging
+
+/**
+ * Convenient and performant wrapper around a given underlying logger.
+ *
+ * Convenient, because you can use string formatting, string interpolation or whatever you want
+ * without thinking too much about performance.
+ * Performant, because by using macros the log methods are expanded inline to the check-enabled idiom.
+ */
+trait AbstractLogger {
+
+  // Fatal
+
+  def fatal(message: String): Unit = {}
+
+  def fatal(message: String, t: Throwable): Unit = {}
+
+  def fatal(message: AnyRef): Unit = {}
+
+  def fatal(message: AnyRef, t: Throwable): Unit = {}
+
+  def fatal(message: String, params: AnyRef*): Unit = {}
+
+  // Error
+
+  def error(message: String): Unit = {}
+
+  def error(message: String, t: Throwable): Unit = {}
+
+  def error(message: AnyRef): Unit = {}
+
+  def error(message: AnyRef, t: Throwable): Unit = {}
+
+  def error(message: String, params: AnyRef*): Unit = {}
+
+  // Warn
+
+  def warn(message: String): Unit = {}
+
+  def warn(message: String, t: Throwable): Unit = {}
+
+  def warn(message: AnyRef): Unit = {}
+
+  def warn(message: AnyRef, t: Throwable): Unit = {}
+
+  def warn(message: String, params: AnyRef*): Unit = {}
+
+  // Info
+
+  def info(message: String): Unit = {}
+
+  def info(message: String, t: Throwable): Unit = {}
+
+  def info(message: AnyRef): Unit = {}
+
+  def info(message: AnyRef, t: Throwable): Unit = {}
+
+  def info(message: String, params: AnyRef*): Unit = {}
+
+  // Debug
+
+  def debug(message: String): Unit = {}
+
+  def debug(message: String, t: Throwable): Unit = {}
+
+  def debug(message: AnyRef): Unit = {}
+
+  def debug(message: AnyRef, t: Throwable): Unit = {}
+
+  def debug(message: String, params: AnyRef*): Unit = {}
+
+  // Trace
+
+  def trace(message: String): Unit = {}
+
+  def trace(message: String, t: Throwable): Unit = {}
+
+  def trace(message: AnyRef): Unit = {}
+
+  def trace(message: AnyRef, t: Throwable): Unit = {}
+
+  def trace(message: String, params: AnyRef*): Unit = {}
+}

--- a/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogging.scala
+++ b/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogging.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012 Copyright 2012 Typesafe Inc. <http://www.typesafe.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.typesafe.scalalogging
+
+/**
+ * Requires the member `logger` of type [[$AbstractLogger]] to be
+ * defined in the class into which this trait is mixed.
+ *
+ * @define Logger com.typesafe.scalalogging.AbstractLogger
+ */
+trait AbstractLogging {
+
+  protected def logger: AbstractLogger
+}

--- a/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logger.scala
+++ b/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logger.scala
@@ -16,6 +16,8 @@
 
 package com.typesafe.scalalogging.log4j
 
+import com.typesafe.scalalogging.AbstractLogger
+
 import language.experimental.macros
 import org.apache.logging.log4j.{ Logger => Underlying, Marker }
 
@@ -36,137 +38,138 @@ object Logger {
  * without thinking too much about performance.
  * Performant, because by using macros the log methods are expanded inline to the check-enabled idiom.
  */
-final class Logger private (val underlying: Underlying) {
+final class Logger private (val underlying: Underlying)
+    extends AbstractLogger {
 
   // Fatal
 
-  def fatal(message: String): Unit = macro LoggerMacros.fatalMessage
+  override def fatal(message: String): Unit = macro LoggerMacros.fatalMessage
 
   def fatal(marker: Marker, message: String): Unit = macro LoggerMacros.fatalMarkerMessage
 
-  def fatal(message: String, t: Throwable): Unit = macro LoggerMacros.fatalMessageThrowable
+  override def fatal(message: String, t: Throwable): Unit = macro LoggerMacros.fatalMessageThrowable
 
   def fatal(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.fatalMarkerMessageThrowable
 
-  def fatal(message: AnyRef): Unit = macro LoggerMacros.fatalAnyRefMessage
+  override def fatal(message: AnyRef): Unit = macro LoggerMacros.fatalAnyRefMessage
 
   def fatal(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.fatalMarkerAnyRefMessage
 
-  def fatal(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.fatalAnyRefMessageThrowable
+  override def fatal(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.fatalAnyRefMessageThrowable
 
   def fatal(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.fatalMarkerAnyRefMessageThrowable
 
-  def fatal(message: String, params: AnyRef*): Unit = macro LoggerMacros.fatalMessageParams
+  override def fatal(message: String, params: AnyRef*): Unit = macro LoggerMacros.fatalMessageParams
 
   def fatal(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.fatalMarkerMessageParams
 
   // Error
 
-  def error(message: String): Unit = macro LoggerMacros.errorMessage
+  override def error(message: String): Unit = macro LoggerMacros.errorMessage
 
   def error(marker: Marker, message: String): Unit = macro LoggerMacros.errorMarkerMessage
 
-  def error(message: String, t: Throwable): Unit = macro LoggerMacros.errorMessageThrowable
+  override def error(message: String, t: Throwable): Unit = macro LoggerMacros.errorMessageThrowable
 
   def error(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.errorMarkerMessageThrowable
 
-  def error(message: AnyRef): Unit = macro LoggerMacros.errorAnyRefMessage
+  override def error(message: AnyRef): Unit = macro LoggerMacros.errorAnyRefMessage
 
   def error(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.errorMarkerAnyRefMessage
 
-  def error(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.errorAnyRefMessageThrowable
+  override def error(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.errorAnyRefMessageThrowable
 
   def error(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.errorMarkerAnyRefMessageThrowable
 
-  def error(message: String, params: AnyRef*): Unit = macro LoggerMacros.errorMessageParams
+  override def error(message: String, params: AnyRef*): Unit = macro LoggerMacros.errorMessageParams
 
   def error(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.errorMarkerMessageParams
 
   // Warn
 
-  def warn(message: String): Unit = macro LoggerMacros.warnMessage
+  override def warn(message: String): Unit = macro LoggerMacros.warnMessage
 
   def warn(marker: Marker, message: String): Unit = macro LoggerMacros.warnMarkerMessage
 
-  def warn(message: String, t: Throwable): Unit = macro LoggerMacros.warnMessageThrowable
+  override def warn(message: String, t: Throwable): Unit = macro LoggerMacros.warnMessageThrowable
 
   def warn(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.warnMarkerMessageThrowable
 
-  def warn(message: AnyRef): Unit = macro LoggerMacros.warnAnyRefMessage
+  override def warn(message: AnyRef): Unit = macro LoggerMacros.warnAnyRefMessage
 
   def warn(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.warnMarkerAnyRefMessage
 
-  def warn(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.warnAnyRefMessageThrowable
+  override def warn(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.warnAnyRefMessageThrowable
 
   def warn(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.warnMarkerAnyRefMessageThrowable
 
-  def warn(message: String, params: AnyRef*): Unit = macro LoggerMacros.warnMessageParams
+  override def warn(message: String, params: AnyRef*): Unit = macro LoggerMacros.warnMessageParams
 
   def warn(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.warnMarkerMessageParams
 
   // Info
 
-  def info(message: String): Unit = macro LoggerMacros.infoMessage
+  override def info(message: String): Unit = macro LoggerMacros.infoMessage
 
   def info(marker: Marker, message: String): Unit = macro LoggerMacros.infoMarkerMessage
 
-  def info(message: String, t: Throwable): Unit = macro LoggerMacros.infoMessageThrowable
+  override def info(message: String, t: Throwable): Unit = macro LoggerMacros.infoMessageThrowable
 
   def info(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.infoMarkerMessageThrowable
 
-  def info(message: AnyRef): Unit = macro LoggerMacros.infoAnyRefMessage
+  override def info(message: AnyRef): Unit = macro LoggerMacros.infoAnyRefMessage
 
   def info(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.infoMarkerAnyRefMessage
 
-  def info(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.infoAnyRefMessageThrowable
+  override def info(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.infoAnyRefMessageThrowable
 
   def info(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.infoMarkerAnyRefMessageThrowable
 
-  def info(message: String, params: AnyRef*): Unit = macro LoggerMacros.infoMessageParams
+  override def info(message: String, params: AnyRef*): Unit = macro LoggerMacros.infoMessageParams
 
   def info(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.infoMarkerMessageParams
 
   // Debug
 
-  def debug(message: String): Unit = macro LoggerMacros.debugMessage
+  override def debug(message: String): Unit = macro LoggerMacros.debugMessage
 
   def debug(marker: Marker, message: String): Unit = macro LoggerMacros.debugMarkerMessage
 
-  def debug(message: String, t: Throwable): Unit = macro LoggerMacros.debugMessageThrowable
+  override def debug(message: String, t: Throwable): Unit = macro LoggerMacros.debugMessageThrowable
 
   def debug(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.debugMarkerMessageThrowable
 
-  def debug(message: AnyRef): Unit = macro LoggerMacros.debugAnyRefMessage
+  override def debug(message: AnyRef): Unit = macro LoggerMacros.debugAnyRefMessage
 
   def debug(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.debugMarkerAnyRefMessage
 
-  def debug(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.debugAnyRefMessageThrowable
+  override def debug(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.debugAnyRefMessageThrowable
 
   def debug(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.debugMarkerAnyRefMessageThrowable
 
-  def debug(message: String, params: AnyRef*): Unit = macro LoggerMacros.debugMessageParams
+  override def debug(message: String, params: AnyRef*): Unit = macro LoggerMacros.debugMessageParams
 
   def debug(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.debugMarkerMessageParams
 
   // Trace
 
-  def trace(message: String): Unit = macro LoggerMacros.traceMessage
+  override def trace(message: String): Unit = macro LoggerMacros.traceMessage
 
   def trace(marker: Marker, message: String): Unit = macro LoggerMacros.traceMarkerMessage
 
-  def trace(message: String, t: Throwable): Unit = macro LoggerMacros.traceMessageThrowable
+  override def trace(message: String, t: Throwable): Unit = macro LoggerMacros.traceMessageThrowable
 
   def trace(marker: Marker, message: String, t: Throwable): Unit = macro LoggerMacros.traceMarkerMessageThrowable
 
-  def trace(message: AnyRef): Unit = macro LoggerMacros.traceAnyRefMessage
+  override def trace(message: AnyRef): Unit = macro LoggerMacros.traceAnyRefMessage
 
   def trace(marker: Marker, message: AnyRef): Unit = macro LoggerMacros.traceMarkerAnyRefMessage
 
-  def trace(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.traceAnyRefMessageThrowable
+  override def trace(message: AnyRef, t: Throwable): Unit = macro LoggerMacros.traceAnyRefMessageThrowable
 
   def trace(marker: Marker, message: AnyRef, t: Throwable): Unit = macro LoggerMacros.traceMarkerAnyRefMessageThrowable
 
-  def trace(message: String, params: AnyRef*): Unit = macro LoggerMacros.traceMessageParams
+  override def trace(message: String, params: AnyRef*): Unit = macro LoggerMacros.traceMessageParams
 
   def trace(marker: Marker, message: String, params: AnyRef*): Unit = macro LoggerMacros.traceMarkerMessageParams
 }

--- a/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logging.scala
+++ b/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logging.scala
@@ -16,17 +16,9 @@
 
 package com.typesafe.scalalogging.log4j
 
+import com.typesafe.scalalogging.AbstractLogging
+
 import org.apache.logging.log4j.LogManager
-
-/**
- * Requires the member `logger` of type [[$Logger]] to be defined in the class into which this trait is mixed.
- *
- * @define Logger com.typesafe.scalalogging.log4j.Logger
- */
-trait AbstractLogging {
-
-  protected def logger: Logger
-}
 
 /**
  * Adds the lazy val `logger` of type [[$Logger]] to the class into which this trait is mixed.

--- a/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logging.scala
+++ b/scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/log4j/Logging.scala
@@ -38,7 +38,7 @@ trait AbstractLogging {
  */
 trait Logging extends AbstractLogging {
 
-  protected lazy val logger: Logger =
+  override protected lazy val logger: Logger =
     Logger(LogManager getLogger getClass.getName)
 }
 
@@ -52,6 +52,6 @@ trait Logging extends AbstractLogging {
  */
 trait StrictLogging extends AbstractLogging {
 
-  protected val logger: Logger =
+  override protected val logger: Logger =
     Logger(LogManager getLogger getClass.getName)
 }

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/AbstractLogger.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/AbstractLogger.scala
@@ -1,0 +1,1 @@
+../../../../../../../scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogger.scala

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/AbstractLogging.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/AbstractLogging.scala
@@ -1,0 +1,1 @@
+../../../../../../../scalalogging-log4j/src/main/scala/com/typesafe/scalalogging/AbstractLogging.scala

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logger.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logger.scala
@@ -16,6 +16,8 @@
 
 package com.typesafe.scalalogging.slf4j
 
+import com.typesafe.scalalogging.AbstractLogger
+
 import language.experimental.macros
 import org.slf4j.{ Logger => Underlying, Marker }
 
@@ -35,15 +37,16 @@ object Logger {
  * without thinking too much about performance.
  * Performant, because by using macros the log methods are expanded inline to the check-enabled idiom.
  */
-final class Logger private (val underlying: Underlying) {
+final class Logger private (val underlying: Underlying)
+    extends AbstractLogger {
 
   // Error
 
-  def error(message: String): Unit = macro LoggerMacros.errorMessage
+  override def error(message: String): Unit = macro LoggerMacros.errorMessage
 
-  def error(message: String, params: AnyRef*): Unit = macro LoggerMacros.errorMessageParams
+  override def error(message: String, params: AnyRef*): Unit = macro LoggerMacros.errorMessageParams
 
-  def error(message: String, t: Throwable): Unit = macro LoggerMacros.errorMessageThrowable
+  override def error(message: String, t: Throwable): Unit = macro LoggerMacros.errorMessageThrowable
 
   def error(marker: Marker, message: String): Unit = macro LoggerMacros.errorMarkerMessage
 
@@ -53,11 +56,11 @@ final class Logger private (val underlying: Underlying) {
 
   // Warn
 
-  def warn(message: String): Unit = macro LoggerMacros.warnMessage
+  override def warn(message: String): Unit = macro LoggerMacros.warnMessage
 
-  def warn(message: String, params: AnyRef*): Unit = macro LoggerMacros.warnMessageParams
+  override def warn(message: String, params: AnyRef*): Unit = macro LoggerMacros.warnMessageParams
 
-  def warn(message: String, t: Throwable): Unit = macro LoggerMacros.warnMessageThrowable
+  override def warn(message: String, t: Throwable): Unit = macro LoggerMacros.warnMessageThrowable
 
   def warn(marker: Marker, message: String): Unit = macro LoggerMacros.warnMarkerMessage
 
@@ -67,11 +70,11 @@ final class Logger private (val underlying: Underlying) {
 
   // Info
 
-  def info(message: String): Unit = macro LoggerMacros.infoMessage
+  override def info(message: String): Unit = macro LoggerMacros.infoMessage
 
-  def info(message: String, params: AnyRef*): Unit = macro LoggerMacros.infoMessageParams
+  override def info(message: String, params: AnyRef*): Unit = macro LoggerMacros.infoMessageParams
 
-  def info(message: String, t: Throwable): Unit = macro LoggerMacros.infoMessageThrowable
+  override def info(message: String, t: Throwable): Unit = macro LoggerMacros.infoMessageThrowable
 
   def info(marker: Marker, message: String): Unit = macro LoggerMacros.infoMarkerMessage
 
@@ -81,11 +84,11 @@ final class Logger private (val underlying: Underlying) {
 
   // Debug
 
-  def debug(message: String): Unit = macro LoggerMacros.debugMessage
+  override def debug(message: String): Unit = macro LoggerMacros.debugMessage
 
-  def debug(message: String, params: AnyRef*): Unit = macro LoggerMacros.debugMessageParams
+  override def debug(message: String, params: AnyRef*): Unit = macro LoggerMacros.debugMessageParams
 
-  def debug(message: String, t: Throwable): Unit = macro LoggerMacros.debugMessageThrowable
+  override def debug(message: String, t: Throwable): Unit = macro LoggerMacros.debugMessageThrowable
 
   def debug(marker: Marker, message: String): Unit = macro LoggerMacros.debugMarkerMessage
 
@@ -95,11 +98,11 @@ final class Logger private (val underlying: Underlying) {
 
   // Trace
 
-  def trace(message: String): Unit = macro LoggerMacros.traceMessage
+  override def trace(message: String): Unit = macro LoggerMacros.traceMessage
 
-  def trace(message: String, params: AnyRef*): Unit = macro LoggerMacros.traceMessageParams
+  override def trace(message: String, params: AnyRef*): Unit = macro LoggerMacros.traceMessageParams
 
-  def trace(message: String, t: Throwable): Unit = macro LoggerMacros.traceMessageThrowable
+  override def trace(message: String, t: Throwable): Unit = macro LoggerMacros.traceMessageThrowable
 
   def trace(marker: Marker, message: String): Unit = macro LoggerMacros.traceMarkerMessage
 

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logging.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logging.scala
@@ -38,7 +38,7 @@ trait AbstractLogging {
  */
 trait Logging extends AbstractLogging {
 
-  protected lazy val logger: Logger =
+  override protected lazy val logger: Logger =
     Logger(LoggerFactory getLogger getClass.getName)
 }
 
@@ -52,6 +52,6 @@ trait Logging extends AbstractLogging {
  */
 trait StrictLogging extends AbstractLogging {
 
-  protected val logger: Logger =
+  override protected val logger: Logger =
     Logger(LoggerFactory getLogger getClass.getName)
 }

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logging.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logging.scala
@@ -16,17 +16,9 @@
 
 package com.typesafe.scalalogging.slf4j
 
+import com.typesafe.scalalogging.AbstractLogging
+
 import org.slf4j.LoggerFactory
-
-/**
- * Requires the member `logger` of type [[$Logger]] to be defined in the class into which this trait is mixed.
- *
- * @define Logger com.typesafe.scalalogging.slf4j.Logger
- */
-trait AbstractLogging {
-
-  protected def logger: Logger
-}
 
 /**
  * Adds the lazy val `logger` of type [[$Logger]] to the class into which this trait is mixed.


### PR DESCRIPTION
This branch moves AbstractLogging from com.typesafe.scalalogging.{log4j,slf4j}.AbstractLogging up a level to com.typesafe.scalalogging.AbstractLogging.  This allows one to abstract over the logging implementation.

Since AbstractLogging returns a logger, I needed to unify the log4j and sl4fj loggers so added AbstractLogger.  Due to restrictions in Scala 2.10 macros, I needed to define the AbstractLogger methods to have the macros work.
