### PR TITLE
Automatically create underlying SLF4J logger with name autodetection

### DIFF
--- a/scalalogging-slf4j-test/src/test/scala/com/typesafe/scalalogging/slf4j/Slf4jLoggerSpec.scala
+++ b/scalalogging-slf4j-test/src/test/scala/com/typesafe/scalalogging/slf4j/Slf4jLoggerSpec.scala
@@ -16,7 +16,7 @@
 
 package com.typesafe.scalalogging.slf4j
 
-import org.slf4j.{ Logger => Underlying, MarkerFactory }
+import org.slf4j.{ Logger => Underlying, ILoggerFactory, LoggerFactory, MarkerFactory }
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
@@ -216,4 +216,23 @@ object Slf4jLoggerSpec extends Specification with Mockito {
       there was one(underlying).trace(Marker, Message, Throwable)
     }
   }
+
+  "Creating logger" should {
+    "provide correct logger name" in {
+      val ilfSpy = spy(LoggerFactory.getILoggerFactory)
+      new TestSuperclass(ilfSpy)
+      there was one(ilfSpy).getLogger("com.typesafe.scalalogging.slf4j.TestSuperclass")
+
+      new TestSubclass(ilfSpy)
+      there was one(ilfSpy).getLogger("com.typesafe.scalalogging.slf4j.TestSubclass")
+    }
+  }
+}
+
+class TestSuperclass(iLoggerFactory: ILoggerFactory) {
+  Logger(iLoggerFactory)
+}
+
+class TestSubclass(iLoggerFactory: ILoggerFactory) extends TestSuperclass(iLoggerFactory) {
+  Logger(iLoggerFactory)
 }

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logger.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/Logger.scala
@@ -17,9 +17,14 @@
 package com.typesafe.scalalogging.slf4j
 
 import language.experimental.macros
-import org.slf4j.{ Logger => Underlying, Marker }
+import org.slf4j.{ Logger => Underlying, LoggerFactory => UnderlyingFactory, ILoggerFactory => IUnderlyingFactory, Marker }
 
 object Logger {
+  /**
+   * Create a [[com.typesafe.scalalogging.slf4j.Logger]] and the underlying `org.slf4j.Logger`.
+   * Autodetect underlying logger name from class in which it was called
+   */
+  def apply(factory: IUnderlyingFactory = UnderlyingFactory.getILoggerFactory): Logger = macro LoggerMacros.createLogger
 
   /**
    * Create a [[com.typesafe.scalalogging.slf4j.Logger]] wrapping the given underlying `org.slf4j.Logger`.

--- a/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/LoggerMacros.scala
+++ b/scalalogging-slf4j/src/main/scala/com/typesafe/scalalogging/slf4j/LoggerMacros.scala
@@ -16,12 +16,19 @@
 
 package com.typesafe.scalalogging.slf4j
 
-import org.slf4j.Marker
+import org.slf4j.{ ILoggerFactory => IUnderlyingFactory, Marker }
 import scala.reflect.macros.Context
 
 private object LoggerMacros {
 
   type LoggerContext = Context { type PrefixType = Logger }
+
+  def createLogger(c: LoggerContext)(factory: c.Expr[IUnderlyingFactory]): c.Expr[Logger] = {
+    import c.universe._
+    val enclClass = c.enclosingClass.symbol.asClass
+    val enclClassLiteral = c.Expr(Literal(Constant(enclClass.fullName)))
+    c.universe.reify(Logger(factory.splice.getLogger(enclClassLiteral.splice)))
+  }
 
   // Error
 


### PR DESCRIPTION
This is solution of some issues described here: https://github.com/typesafehub/scalalogging/issues/28
Subclassing from Logging trait can make impossible to configure logging level for some classes, and writing long string like this:

```
val log = Logger(LoggerFactory.getLogger(classOf[HereGoesCurrentClassName]))
```

can be tedious.
With this patch underlying logger name can be detected automatically via macros. All you need to do is:

```
val log = Logger()
```

It finds nearest encircling class and uses its name for creating underlying logger.
